### PR TITLE
chore: Setup env var at runtime

### DIFF
--- a/.github/workflows/javascript-workflow.yml
+++ b/.github/workflows/javascript-workflow.yml
@@ -71,8 +71,10 @@ jobs:
           tags="-t aukilabs/${IMAGE_NAME}:${{ github.sha }} -t aukilabs/${IMAGE_NAME}:${ref_name_tag}"
           test "${{ inputs.enable_tag_latest }}" = "true" && tags="${tags} -t aukilabs/${IMAGE_NAME}:latest"
 
+          next_build_args="--build-arg NEXT_PUBLIC_AMPLITUDE_API_KEY=__NEXT_PUBLIC_AMPLITUDE_API_KEY__"
+
           docker buildx create --use
-          docker buildx build --platform linux/amd64 $tags --push .
+          docker buildx build $next_build_args --platform linux/amd64 $tags --push .
 
       - name: Authenticate ArgoCD
         uses: clowdhaus/argo-cd-action@v2.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
 FROM node:20-alpine AS builder
+ARG NEXT_PUBLIC_AMPLITUDE_API_KEY=__NEXT_PUBLIC_AMPLITUDE_API_KEY__
 WORKDIR /app
 RUN apk add --no-cache git bash curl build-base
 
@@ -20,6 +21,7 @@ RUN git init /root
 COPY package*.json ./
 RUN npm ci
 COPY . .
+ENV NEXT_PUBLIC_AMPLITUDE_API_KEY=$NEXT_PUBLIC_AMPLITUDE_API_KEY
 RUN npm run build
 
 # Production stage
@@ -36,9 +38,11 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Set correct permissions
 RUN chown -R nextjs:nodejs /app
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 USER nextjs
 
@@ -47,4 +51,5 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/charts/domain-viewer/templates/config.yaml
+++ b/charts/domain-viewer/templates/config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: domain-viewer
+data:
+  40-next-public-env-vars.sh: |
+    #!/bin/sh
+    set -eu
+
+    var_name="NEXT_PUBLIC_AMPLITUDE_API_KEY"
+    eval_cmd="echo \"\$${var_name}\""
+    var_value="$(eval "${eval_cmd}")"
+    sed_script="s~__${var_name}__~${var_value}~g"
+
+    if [ -d /app/.next ]; then
+      find /app/.next -type f -name '*.js' -exec sed -i "${sed_script}" {} \;
+    fi
+
+    if [ -f /app/server.js ]; then
+      sed -i "${sed_script}" /app/server.js
+    fi

--- a/charts/domain-viewer/values.yaml
+++ b/charts/domain-viewer/values.yaml
@@ -29,6 +29,18 @@ k8s-service:
   envVars:
     AUKI_API_SERVER: http://api
     AUKI_DDS_SERVER: http://dds
+    NEXT_PUBLIC_AMPLITUDE_API_KEY: ""
+  configMaps:
+    domain-viewer:
+      as: volume
+      mountPath: /docker-entrypoint.d/40-next-public-env-vars.sh
+      subPath: 40-next-public-env-vars.sh
+      items:
+        40-next-public-env-vars.sh:
+          envVarName: 40-next-public-env-vars.sh
+          fileMode: 500
+          filePath: 40-next-public-env-vars.sh
+      name: domain-viewer
   secrets:
     domain-viewer:
       as: envFrom

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+if [ -d /docker-entrypoint.d ]; then
+  for script in /docker-entrypoint.d/*.sh; do
+    [ -f "$script" ] || continue
+    echo "Running startup script: $script"
+    sh "$script"
+  done
+fi
+
+exec "$@"

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -60,7 +60,7 @@ export function initAnalytics() {
   if (initialized) return;
 
   const apiKey = process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY;
-  if (!apiKey) {
+  if (!apiKey || apiKey.startsWith("__NEXT_PUBLIC_")) {
     console.warn("[Analytics] NEXT_PUBLIC_AMPLITUDE_API_KEY not set, skipping init");
     return;
   }


### PR DESCRIPTION
This PR implements runtime env injection for domain-viewer, so NEXT_PUBLIC_AMPLITUDE_API_KEY can be changed at deploy/runtime without rebuilding the image.